### PR TITLE
Add retries into assigning folder permissions

### DIFF
--- a/ForgeBimApi/ForgeBimApiWrappers/BimProjectFoldersApi.cs
+++ b/ForgeBimApi/ForgeBimApiWrappers/BimProjectFoldersApi.cs
@@ -471,9 +471,29 @@ namespace Autodesk.Forge.BIM360
             request.AddHeader("Content-Type", "application/json");
             request.AddHeader("x-user-id", userId);
 
-            IRestResponse response = ExecuteRequest(request);
+            int retriesRemaining = 5;
+            while (retriesRemaining > 0)
+            {
+                retriesRemaining--;
+                IRestResponse response = ExecuteRequest(request);
 
-            return response.StatusCode == System.Net.HttpStatusCode.OK;
+                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                {
+                    return true;
+                }
+                else if(retriesRemaining > 0)
+                {
+                    Log.Warn($"Failed to assgn role permissions to folder: {folderId}. Retry {retriesRemaining} more times...");
+                    
+                    Thread.Sleep(15000);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return false;
         }
 
 


### PR DESCRIPTION
Assigning role-based permissions when copying project folders fails in some cases. I've added retry logic to give BIM 360 time to finish creating the folder.

Resolves issue #20 